### PR TITLE
Prevent users from being logout by a malicious img tag.

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -8,10 +8,11 @@ use Illuminate\Http\Request;
 class LoginController extends Controller
 {
     //
-    public function logout()
+    public function logout(Request $request)
     {
-        \Auth::logout();
-
+        if (strpos($request->header('accept'), 'text/html') !== false) {
+            \Auth::logout();
+        }
         return redirect()->to('/');
     }
 


### PR DESCRIPTION
By judging whether the Accept field in request-headers contains 'text/html' to determine if the request is from a img tag.
If it is, then just simply ignore it.